### PR TITLE
added option to switch on led strip only when printer is connected

### DIFF
--- a/octoprint_rgb_status/__init__.py
+++ b/octoprint_rgb_status/__init__.py
@@ -27,6 +27,7 @@ STRIP_TYPES = {
     'SK6812W_STRIP': SK6812W_STRIP,
 }
 IDLE_SETTINGS = ['idle_effect', 'idle_effect_color', 'idle_effect_delay', 'idle_effect_iterations']
+DISCONNECTED_SETTINGS = ['disconnected_effect', 'disconnected_effect_color', 'disconnected_effect_delay', 'disconnected_effect_iterations']
 EFFECTS = {
     'Solid Color': solid_color,
     'Color Wipe': color_wipe,
@@ -151,7 +152,6 @@ class RGBStatusPlugin(
             'led_brightness': 255,
             'led_invert': False,
             'led_channel': 0,
-            'only_when_connected': False,
             'strip_type': 'WS2811_STRIP_GRB',
 
             'show_progress': True,
@@ -177,6 +177,10 @@ class RGBStatusPlugin(
             'done_effect': 'Pulse',
             'done_effect_color': '#00ff00',
             'done_effect_delay': 10,
+
+            'disconnected_effect': 'Solid Color',
+            'disconnected_effect_color': '#000000',
+            'disconnected_effect_delay': 10,
         }
 
     def on_settings_save(self, data):
@@ -187,16 +191,25 @@ class RGBStatusPlugin(
         old_idle_settings = {}
         for setting in IDLE_SETTINGS:
             old_idle_settings[setting] = self._settings.get([setting])
+        old_disconnected_settings = {}
+        for setting in DISCONNECTED_SETTINGS:
+            old_disconnected_settings[setting] = self._settings.get([setting])
 
         changed_settings = plugin.SettingsPlugin.on_settings_save(self, data)
         for setting in STRIP_SETTINGS:
             if old_strip_settings[setting] != self._settings.get([setting]):
                 self.init_strip()
                 break
-        for setting in IDLE_SETTINGS:
-            if old_idle_settings[setting] != self._settings.get([setting]):
-                self.run_idle_effect()
-                break
+        if self._printer.is_operational():
+            for setting in IDLE_SETTINGS:
+                if old_idle_settings[setting] != self._settings.get([setting]):
+                    self.run_idle_effect()
+                    break
+        else:
+            for setting in DISCONNECTED_SETTINGS:
+                if old_disconnected_settings[setting] != self._settings.get([setting]):
+                    self.run_disconnected_effect()
+                    break
         return changed_settings
 
     def get_template_configs(self):
@@ -229,13 +242,15 @@ class RGBStatusPlugin(
         except Exception as e:
             self._logger.error(e)
             self.strip = None
-        if self._settings.get_boolean(['only_when_connected']) == False or self._printer.is_operational():
-            self.run_effect(
-                self._settings.get(['init_effect']),
-                hex_to_rgb(self._settings.get(['init_effect_color'])),
-                self._settings.get_int(['init_effect_delay']),
-            )
+        self.run_effect(
+            self._settings.get(['init_effect']),
+            hex_to_rgb(self._settings.get(['init_effect_color'])),
+            self._settings.get_int(['init_effect_delay']),
+        )
+        if self._printer.is_operational():
             self.run_idle_effect()
+        else:
+            self.run_disconnected_effect()
 
     def on_after_startup(self):
         self.init_strip()
@@ -272,6 +287,14 @@ class RGBStatusPlugin(
             self._settings.get_int(['done_effect_delay']),
         )
 
+    def run_disconnected_effect(self):
+        self._logger.info('Starting Disconnected Effect')
+        self.run_effect(
+            self._settings.get(['disconnected_effect']),
+            hex_to_rgb(self._settings.get(['disconnected_effect_color'])),
+            self._settings.get_int(['disconnected_effect_delay']),
+        )
+
     def on_event(self, event, payload):
         if event == 'PrintStarted':
             progress_base_color = hex_to_rgb(self._settings.get(['progress_base_color']))
@@ -284,12 +307,10 @@ class RGBStatusPlugin(
             self.run_done_effect()
         elif event == 'PrintCancelled':
             self.run_idle_effect()
-        elif self._settings.get_boolean(['only_when_connected']) and event == 'Connected':
+        elif event == 'Connected':
             self.run_idle_effect()
         elif event == 'Disconnected':
-            self._logger.info('Disconnected; Killing Effect')
-            self.kill_effect()
-            self.run_effect('Solid Color', (0,0,0), 200)
+            self.run_disconnected_effect()
 
     def on_print_progress(self, storage, path, progress):
 	if progress == 100 and hasattr(self, '_effect') and self._effect.is_alive():

--- a/octoprint_rgb_status/templates/rgb_status_settings.jinja2
+++ b/octoprint_rgb_status/templates/rgb_status_settings.jinja2
@@ -59,14 +59,6 @@
 	    <span class="help-inline">Set to '1' for GPIOs 13, 19, 41, 45 or 53</span>
         </div>
     </div>
-    <div class="control-group">
-        <label class="control-label" for="connectedOnly">{{ _('Only when connected') }}</label>
-        <div class="controls">
-            <input type="checkbox" class="input-block-level" id="connectedOnly" data-bind="checked: settings.plugins.rgb_status.only_when_connected">
-            <span class="help-inline">Activate the LED strip only when the printer is connected to octoprint.</span>
-        </div>
-    </div>
-
 
     <h4>Progress Bar Settings</h4>
     <div class="control-group">
@@ -213,6 +205,31 @@
         <label class="control-label" for="doneEffectDelay">{{ _('Finish Effect Delay') }}</label>
         <div class="controls">
             <input type="number" class="input-block-level" id="doneEffectDelay" data-bind="value: settings.plugins.rgb_status.done_effect_delay">
+        </div>
+    </div>
+
+    <h4>Disconnected Effect Settings</h4>
+    <p>Configure the effect that is run when the printer is not connected.</p>
+    <div class="control-group">
+        <label class="control-label" for="disconnectedEffect">{{ _('Disconnected Effect') }}</label>
+        <div class="controls">
+            <select class="input-block-level" id="disconnectedEffect" data-bind="value: settings.plugins.rgb_status.disconnected_effect">
+		{% for effect in plugin_rgb_status_effects %}
+	            <option value="{{ effect }}">{{ effect }}</option>
+		{% endfor %}
+	    </select>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="disconnectedEffectColor">{{ _('Disconnected Effect Color') }}</label>
+        <div class="controls">
+            <input type="color" class="input-block-level" id="disconnectedEffectColor" data-bind="value: settings.plugins.rgb_status.disconnected_effect_color">
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label" for="disconnectedEffectDelay">{{ _('Disconnected Effect Delay') }}</label>
+        <div class="controls">
+            <input type="number" class="input-block-level" id="disconnectedEffectDelay" data-bind="value: settings.plugins.rgb_status.disconnected_effect_delay">
         </div>
     </div>
 </form>

--- a/octoprint_rgb_status/templates/rgb_status_settings.jinja2
+++ b/octoprint_rgb_status/templates/rgb_status_settings.jinja2
@@ -59,6 +59,14 @@
 	    <span class="help-inline">Set to '1' for GPIOs 13, 19, 41, 45 or 53</span>
         </div>
     </div>
+    <div class="control-group">
+        <label class="control-label" for="connectedOnly">{{ _('Only when connected') }}</label>
+        <div class="controls">
+            <input type="checkbox" class="input-block-level" id="connectedOnly" data-bind="checked: settings.plugins.rgb_status.only_when_connected">
+            <span class="help-inline">Activate the LED strip only when the printer is connected to octoprint.</span>
+        </div>
+    </div>
+
 
     <h4>Progress Bar Settings</h4>
     <div class="control-group">


### PR DESCRIPTION
I added an option to the settings menu disable the led strip when the printer is not connected. Idle mode is started when when the printer is connected and turned off on disconnect.